### PR TITLE
Update render-specs.yml

### DIFF
--- a/.github/workflows/render-specs.yml
+++ b/.github/workflows/render-specs.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-deploy-spec:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.


### PR DESCRIPTION
Ran into a problem deploying the spec-up for a new specification in a new repo.

The publish job is failed with this message:

```
/usr/bin/git push origin --force gh-pages
  remote: Permission to dhh1128/did-method-webs.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/dhh1128/did-method-webs.git/': The requested URL returned error: 403
  Error: Action failed with "The process '/usr/bin/git' failed with exit code 128"
```

Per [this note](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-first-deployment-with-github_token), this change fixed it for the new spec we were publishing.

I think the change is needed generally, so adding this PR to the spec-up repo.